### PR TITLE
Selector proposal

### DIFF
--- a/src/processModules.js
+++ b/src/processModules.js
@@ -2,41 +2,27 @@ import {handleActions} from 'redux-actions'
 
 export default function processModules(modules) {
   const reducers = modules
-    .filter(module => (
-      typeof module.reducer == 'function' || typeof module.reducer == 'object'
-    ))
-    .map(module => (
-      typeof module.reducer == 'function' ? module.reducer : handleActions(module.reducer)
-    ))
+    .map(module => module.reducer)
+    .filter(reducer => typeof reducer == 'function' || typeof reducer == 'object')
+    .map(reducer => typeof reducer == 'function' ? reducer : handleActions(reducer))
 
   const middlewares = modules
-    .filter(module => (
-      typeof module.middleware == 'function' || typeof module.middleware == 'object'
-    ))
-    .map(module => (
-      typeof module.middleware == 'function' ? module.middleware : handleMiddlewares(module.middleware)
-    ))
+    .map(module => module.middleware)
+    .filter(middleware => typeof middleware == 'function' || typeof middleware == 'object')
+    .map(middleware => typeof middleware == 'function' ? middleware : handleMiddlewares(middleware))
 
   const enhancers = modules
-    .filter(module => (
-      typeof module.enhancer == 'function'
-    ))
     .map(module => module.enhancer)
+    .filter(enhancer => typeof enhancer == 'function')
 
   return {
     reducers,
     middlewares,
-    enhancers
+    enhancers,
   }
 }
 
-export function handleMiddlewares(listeners) {
-  return store => next => action => {
-    // Execute action listeners, if any was set for the current action.
-    if (listeners[action.type]) {
-      return listeners[action.type](store)(next)(action)
-    }
-
-    return next(action)
-  }
-}
+export const handleMiddlewares = (listeners) => store => next => action => (
+  // Execute action listeners, if any was set for the current action.
+  listeners[action.type] ? listeners[action.type](store)(next)(action) : next(action)
+)


### PR DESCRIPTION
Redux-boot does not rely on combinators. Sometimes when we need to simply attach reducers from other projects the code can be unnecessarily big. Take as an example the usage of redux-form reducer:

```js
import { reducer } from 'redux-form'

const formModule = {
  reducer: (state, action) => ({
    ...state,
    form: reducer(state.form, action)
  })
}
```

This is not really bad, but maybe we could do the following:

```js
import { reducer } from 'redux-form'

const formModule = {
  selector: 'form',
  reducer
}
```

Basically, what this pull-request accomplishes is wrap any reducer and resolve "selector" paths.