### PR TITLE
Redux actions and tests bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-boot",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Minimal Framework using Redux to develop modularized universal Apps.",
   "main": "lib/index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "babel-runtime": "^6.6.1",
     "redux": "^3.3.1",
-    "redux-actions": "^0.9.1",
+    "redux-actions": "^2.2.1",
     "redux-promise": "^0.5.3"
   },
   "devDependencies": {
@@ -37,7 +37,7 @@
     "gitbook-cli": "^2.1.3",
     "json-loader": "^0.5.4",
     "redux": "^3.3.1",
-    "redux-actions": "^0.9.1",
+    "redux-actions": "^2.2.1",
     "redux-promise": "^0.5.3",
     "symbol-observable": "^0.2.2",
     "tap-spec": "^4.1.1",

--- a/src/processModules.js
+++ b/src/processModules.js
@@ -2,32 +2,25 @@ import {handleActions} from 'redux-actions'
 
 export default function processModules(modules) {
   const reducers = modules
-    .filter(
-      module =>
-        typeof module.reducer == 'function' || typeof module.reducer == 'object'
-    )
-    .map(
-      module =>
-        typeof module.reducer == 'function'
-          ? module.reducer
-          : handleActions(module.reducer, {})
-    )
+    .filter(module => (
+      typeof module.reducer == 'function' || typeof module.reducer == 'object'
+    ))
+    .map(module => (
+      typeof module.reducer == 'function' ? module.reducer : handleActions(module.reducer, {})
+    ))
 
   const middlewares = modules
-    .filter(
-      module =>
-        typeof module.middleware == 'function' ||
-        typeof module.middleware == 'object'
-    )
-    .map(
-      module =>
-        typeof module.middleware == 'function'
-          ? module.middleware
-          : handleMiddlewares(module.middleware)
-    )
+    .filter(module => (
+        typeof module.middleware == 'function' || typeof module.middleware == 'object'
+    ))
+    .map(module => (
+        typeof module.middleware == 'function' ? module.middleware : handleMiddlewares(module.middleware)
+    ))
 
   const enhancers = modules
-    .filter(module => typeof module.enhancer == 'function')
+    .filter(module => (
+      typeof module.enhancer == 'function'
+    ))
     .map(module => module.enhancer)
 
   return {

--- a/src/processModules.js
+++ b/src/processModules.js
@@ -2,25 +2,32 @@ import {handleActions} from 'redux-actions'
 
 export default function processModules(modules) {
   const reducers = modules
-    .filter(module => (
-      typeof module.reducer == 'function' || typeof module.reducer == 'object'
-    ))
-    .map(module => (
-      typeof module.reducer == 'function' ? module.reducer : handleActions(module.reducer)
-    ))
+    .filter(
+      module =>
+        typeof module.reducer == 'function' || typeof module.reducer == 'object'
+    )
+    .map(
+      module =>
+        typeof module.reducer == 'function'
+          ? module.reducer
+          : handleActions(module.reducer, {})
+    )
 
   const middlewares = modules
-    .filter(module => (
-      typeof module.middleware == 'function' || typeof module.middleware == 'object'
-    ))
-    .map(module => (
-      typeof module.middleware == 'function' ? module.middleware : handleMiddlewares(module.middleware)
-    ))
+    .filter(
+      module =>
+        typeof module.middleware == 'function' ||
+        typeof module.middleware == 'object'
+    )
+    .map(
+      module =>
+        typeof module.middleware == 'function'
+          ? module.middleware
+          : handleMiddlewares(module.middleware)
+    )
 
   const enhancers = modules
-    .filter(module => (
-      typeof module.enhancer == 'function'
-    ))
+    .filter(module => typeof module.enhancer == 'function')
     .map(module => module.enhancer)
 
   return {

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -33,6 +33,7 @@ test('Example with a simple reducer', assert => {
     )
     assert.end()
   })
+
 })
 
 test('Example with a simple reducer and a sync middleware', assert => {
@@ -64,7 +65,9 @@ test('Example with a simple reducer and a sync middleware', assert => {
     }
   }
 
-  const modules = [testModule]
+  const modules = [
+    testModule
+  ]
 
   const app = boot(initialState, modules)
 
@@ -76,6 +79,7 @@ test('Example with a simple reducer and a sync middleware', assert => {
     )
     assert.end()
   })
+
 })
 
 test('Example with a simple reducer and an async middleware', assert => {
@@ -112,7 +116,9 @@ test('Example with a simple reducer and an async middleware', assert => {
     }
   }
 
-  const modules = [testModule]
+  const modules = [
+    testModule
+  ]
 
   const app = boot(initialState, modules)
 
@@ -124,6 +130,7 @@ test('Example with a simple reducer and an async middleware', assert => {
     )
     assert.end()
   })
+
 })
 
 test('Example with a simple reducer and an async middleware (Netflix Roulette API)', assert => {
@@ -181,7 +188,9 @@ test('Example with a simple reducer and an async middleware (Netflix Roulette AP
   }
 
   // Declare the modules you want to use.
-  const modules = [testModule]
+  const modules = [
+    testModule
+  ]
 
   // Create the App.
   const app = boot(initialState, modules)
@@ -196,6 +205,7 @@ test('Example with a simple reducer and an async middleware (Netflix Roulette AP
 
     assert.end()
   })
+
 })
 
 test('Example of reacting (side-effect) before and after an action', assert => {
@@ -204,15 +214,11 @@ test('Example of reacting (side-effect) before and after an action', assert => {
 
   const requestApiAction = createAction(REQUEST_API, async path => {
     return new Promise((resolve, reject) => {
-      setTimeout(
-        () =>
-          resolve({
+      setTimeout(() => resolve({
             id: 24,
             name: 'Irlanda'
-          }),
-        1
-      )
-    })
+          }), 1)
+      })
   })
 
   const initialState = {
@@ -259,7 +265,7 @@ test('Example of reacting (side-effect) before and after an action', assert => {
           store.getState(),
           {
             loading: false,
-            request: {id: 24, name: 'Irlanda'}
+            request: { id: 24, name: 'Irlanda' }
           },
           'loading is done'
         )
@@ -269,7 +275,10 @@ test('Example of reacting (side-effect) before and after an action', assert => {
     }
   }
 
-  const modules = [loaderModule]
+  const modules = [
+    loaderModule
+  ]
 
-  const app = boot(initialState, modules).then(() => assert.end())
+  const app = boot(initialState, modules)
+    .then(() => assert.end())
 })

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -21,9 +21,7 @@ test('Example with a simple reducer', assert => {
     }
   }
 
-  const modules = [
-    testModule
-  ]
+  const modules = [testModule]
 
   const app = boot(initialState, modules)
 
@@ -31,11 +29,10 @@ test('Example with a simple reducer', assert => {
     assert.equal(
       store.getState().foo,
       'baz',
-      "State was changed by testModule reducer during the bootstrap"
+      'State was changed by testModule reducer during the bootstrap'
     )
     assert.end()
   })
-
 })
 
 test('Example with a simple reducer and a sync middleware', assert => {
@@ -67,9 +64,7 @@ test('Example with a simple reducer and a sync middleware', assert => {
     }
   }
 
-  const modules = [
-    testModule
-  ]
+  const modules = [testModule]
 
   const app = boot(initialState, modules)
 
@@ -77,18 +72,16 @@ test('Example with a simple reducer and a sync middleware', assert => {
     assert.equal(
       store.getState().foo,
       'baz',
-      "State was changed by testModule reducer with data from middleware"
+      'State was changed by testModule reducer with data from middleware'
     )
     assert.end()
   })
-
 })
 
 test('Example with a simple reducer and an async middleware', assert => {
   const CHANGE_FOO = 'redux-boot/test/CHANGE_FOO'
 
   const changeFoo = createAction(CHANGE_FOO, async value => {
-
     return new Promise((resolve, reject) => {
       setTimeout(() => resolve(value), 1)
     })
@@ -119,9 +112,7 @@ test('Example with a simple reducer and an async middleware', assert => {
     }
   }
 
-  const modules = [
-    testModule
-  ]
+  const modules = [testModule]
 
   const app = boot(initialState, modules)
 
@@ -129,28 +120,24 @@ test('Example with a simple reducer and an async middleware', assert => {
     assert.equal(
       store.getState().foo,
       'baz',
-      "State was changed by testModule reducer with data from async middleware"
+      'State was changed by testModule reducer with data from async middleware'
     )
     assert.end()
   })
-
 })
 
-test('Example with a simple reducer and an async middleware (Spotify API)', assert => {
-
+test('Example with a simple reducer and an async middleware (Netflix Roulette API)', assert => {
   // Declare the initial state of your App.
   const initialState = {
-    artist: ''
+    movie: ''
   }
 
-  const SPOTIFY_SEARCH = 'redux-boot/test/SPOTIFY_SEARCH'
+  const NETFLIX_SEARCH = 'redux-boot/test/NETFLIX_SEARCH'
 
-  const spotifySearchAction = createAction(SPOTIFY_SEARCH, async (name, type) => {
-
-    const result = await axios.get('https://api.spotify.com/v1/search', {
+  const netflixSearchAction = createAction(NETFLIX_SEARCH, async title => {
+    const result = await axios.get('http://netflixroulette.net/api/api.php', {
       params: {
-        q: name,
-        type: type
+        title: title
       }
     })
 
@@ -159,18 +146,15 @@ test('Example with a simple reducer and an async middleware (Spotify API)', asse
 
   // Declare your module.
   const testModule = {
-
     // Reducers handlers.
     reducer: {
-
       // Modify state reacting to a Spotify Search.
-      [SPOTIFY_SEARCH]: {
+      [NETFLIX_SEARCH]: {
         // The search was a success.
         next(state, action) {
-          const firstArtist = action.payload.data.artists.items[0]
           return {
             ...state,
-            artist: firstArtist.name
+            movie: action.payload.data.show_title
           }
         },
         // The search was a failure.
@@ -184,34 +168,29 @@ test('Example with a simple reducer and an async middleware (Spotify API)', asse
     // Middleware handlers.
     middleware: {
       [BOOT]: store => next => async action => {
-
         const nextResult = next(action)
 
         // Dispatch a side-effect action to alter (create) the state.
         // In this case we are searching for an artist which the name
         // starts with "led".
-        await store.dispatch(spotifySearchAction('led', 'artist'))
+        await store.dispatch(netflixSearchAction('breaking bad'))
 
         return nextResult
       }
     }
-
   }
 
   // Declare the modules you want to use.
-  const modules = [
-    testModule
-  ]
+  const modules = [testModule]
 
   // Create the App.
   const app = boot(initialState, modules)
 
   // When the App is
   app.then(({action, store}) => {
-
     assert.equal(
-      store.getState().artist,
-      'Led Zeppelin',
+      store.getState().movie,
+      'Breaking Bad',
       'A side-effect of BOOT action modified the state using a middleware and reducer handler.'
     )
 
@@ -220,16 +199,19 @@ test('Example with a simple reducer and an async middleware (Spotify API)', asse
 })
 
 test('Example of reacting (side-effect) before and after an action', assert => {
-
   const REQUEST_API = 'redux-boot/test/REQUEST_API'
   const LOADING = 'redux-boot/test/LOADING'
 
   const requestApiAction = createAction(REQUEST_API, async path => {
     return new Promise((resolve, reject) => {
-      setTimeout(() => resolve({
-        id: 24,
-        name: 'Irlanda'
-      }), 1)
+      setTimeout(
+        () =>
+          resolve({
+            id: 24,
+            name: 'Irlanda'
+          }),
+        1
+      )
     })
   })
 
@@ -254,13 +236,11 @@ test('Example of reacting (side-effect) before and after an action', assert => {
     },
     middleware: {
       [BOOT]: store => next => action => {
-        
         store.dispatch(requestApiAction('user/23'))
 
         return next(action)
       },
       [REQUEST_API]: store => next => action => {
-
         // Show the loader.
         store.dispatch({type: LOADING, payload: true})
 
@@ -279,7 +259,7 @@ test('Example of reacting (side-effect) before and after an action', assert => {
           store.getState(),
           {
             loading: false,
-            request: { id: 24, name: 'Irlanda' }
+            request: {id: 24, name: 'Irlanda'}
           },
           'loading is done'
         )
@@ -289,10 +269,7 @@ test('Example of reacting (side-effect) before and after an action', assert => {
     }
   }
 
-  const modules = [
-    loaderModule
-  ]
+  const modules = [loaderModule]
 
-  const app = boot(initialState, modules)
-    .then(() => assert.end())
+  const app = boot(initialState, modules).then(() => assert.end())
 })


### PR DESCRIPTION
defaultState in handleActions is used to initialState, but in redux-boot you can pass the initial state when you start the app `const app = boot(initialState, modules)` or using `BOOT` action in a reducer. So defaultState from handleActions is not needed. I just passed an empty object to solve this error.